### PR TITLE
게시글 상세 조회 API 기능 추가

### DIFF
--- a/src/main/java/com/igocst/coco/controller/PostController.java
+++ b/src/main/java/com/igocst/coco/controller/PostController.java
@@ -28,8 +28,9 @@ public class PostController {
 
     // 게시글 상세 조회
     @GetMapping("/post/{postId}")
-    public PostReadResponseDto readPost(@PathVariable Long postId) {
-        return postService.readPost(postId);
+    public PostReadResponseDto readPost(@PathVariable Long postId,
+                                        @AuthenticationPrincipal MemberDetails memberDetails) {
+        return postService.readPost(postId, memberDetails);
     }
 
     // 게시글 전체 목록 조회

--- a/src/main/java/com/igocst/coco/dto/post/PostReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/post/PostReadResponseDto.java
@@ -23,4 +23,7 @@ public class PostReadResponseDto {
     private int hits;
     private LocalDateTime postDate;
     private String writer;  // 글 작성자 닉네임
+    // 게시글을 수정,삭제 할 수 있는지 여부 체크
+    private boolean enableUpdate;
+    private boolean enableDelete;
 }

--- a/src/main/java/com/igocst/coco/service/PostService.java
+++ b/src/main/java/com/igocst/coco/service/PostService.java
@@ -51,12 +51,20 @@ public class PostService {
     }
 
     // 게시글 내용(상세) 조회
-    public PostReadResponseDto readPost(Long postId) {
+    public PostReadResponseDto readPost(Long postId, MemberDetails memberDetails) {
         // 로그인된 사용자의 정보가 필요 (로그인된 사용자가 아니면 접근 불가, JWT로 인증이 안되면 접근 불가)
 
         // 1. postId에 해당하는 게시글 조회
         Post findPost = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
+        boolean enableUpdate = false;
+        boolean enableDelete = false;
+
+        // 2. 현재 로그인한 회원이 해당 게시글을 작성한 회원이 맞다면 수정, 삭제 가능
+        if (memberDetails.getMember().getId() == findPost.getMember().getId()) {
+            enableUpdate = true;
+            enableDelete = true;
+        }
 
         return PostReadResponseDto.builder()
                 .status("200")
@@ -70,6 +78,8 @@ public class PostService {
                 .hits(findPost.getHits())
                 .postDate(findPost.getLastModifiedDate())
                 .writer(findPost.getMember().getNickname())
+                .enableUpdate(enableUpdate)
+                .enableDelete(enableDelete)
                 .build();
     }
 


### PR DESCRIPTION
서버에서 클라이언트로 게시글 상세 정보를 보낼 때, 수정/삭제 가능 여부도 함께 보내도록 하는 기능 추가