### PR TITLE
게시글 상세 조회 API 기능 추가

### DIFF
--- a/src/main/java/com/igocst/coco/dto/post/PostReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/post/PostReadResponseDto.java
@@ -1,6 +1,7 @@
 package com.igocst.coco.dto.post;
 
 import com.igocst.coco.domain.MeetingType;
+import com.igocst.coco.domain.MemberRole;
 import com.igocst.coco.domain.Post;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,4 +27,6 @@ public class PostReadResponseDto {
     // 게시글을 수정,삭제 할 수 있는지 여부 체크
     private boolean enableUpdate;
     private boolean enableDelete;
+    // 관리자 여부 체크 (관리자는 모든 게시글 삭제 가능)
+    private MemberRole memberRole;
 }

--- a/src/main/java/com/igocst/coco/repository/PostRepository.java
+++ b/src/main/java/com/igocst/coco/repository/PostRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     // 모집 중인 게시글만 가져온다.
-    List<Post> findAllByRecruitmentStateTrue();
+    List<Post> findAllByRecruitmentStateFalse();
 }

--- a/src/main/java/com/igocst/coco/service/PostService.java
+++ b/src/main/java/com/igocst/coco/service/PostService.java
@@ -1,6 +1,7 @@
 package com.igocst.coco.service;
 
 import com.igocst.coco.domain.Member;
+import com.igocst.coco.domain.MemberRole;
 import com.igocst.coco.domain.Post;
 import com.igocst.coco.dto.post.*;
 import com.igocst.coco.repository.MemberRepository;
@@ -66,6 +67,14 @@ public class PostService {
             enableDelete = true;
         }
 
+        // 3. 현재 로그인한 회원이 관리자면, 모든 게시글 삭제 가능
+        MemberRole memberRole = MemberRole.MEMBER;
+        if (memberDetails.getMember().getRole().equals(MemberRole.ADMIN)) {
+            memberRole = MemberRole.ADMIN;
+            enableDelete = true;
+        }
+
+
         return PostReadResponseDto.builder()
                 .status("200")
                 .id(findPost.getId())
@@ -80,6 +89,7 @@ public class PostService {
                 .writer(findPost.getMember().getNickname())
                 .enableUpdate(enableUpdate)
                 .enableDelete(enableDelete)
+                .memberRole(memberRole)
                 .build();
     }
 
@@ -111,7 +121,7 @@ public class PostService {
 
     // 게시글 목록 조회 (모집 중인거만)
     public List<PostReadResponseDto> readRecruitingPostList() {
-        List<Post> recrutingPosts = postRepository.findAllByRecruitmentStateTrue();
+        List<Post> recrutingPosts = postRepository.findAllByRecruitmentStateFalse();
 
         List<PostReadResponseDto> recrutingPostList = new ArrayList<>();
         for (Post post : recrutingPosts) {


### PR DESCRIPTION
서버에서 클라이언트로 게시글 상세 정보를 보낼 때, 관리자 여부도 함께 보내도록 하는 기능 추가