### PR TITLE
댓글 Time ago 기능 구현

### DIFF
--- a/src/main/java/com/igocst/coco/domain/Comment.java
+++ b/src/main/java/com/igocst/coco/domain/Comment.java
@@ -5,6 +5,7 @@ import com.igocst.coco.domain.timestamped.Timestamped;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Setter
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Comment extends Timestamped {
+public class Comment {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) //MySQL에서는 IDENTITY가 먹힌다. (오라클 등에서는 안먹힘!)
     @Column(name = "COMMENT_ID")
@@ -30,6 +31,9 @@ public class Comment extends Timestamped {
 
     @Column(nullable = false)
     private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createDate;
 
     public void addMember(Member member) {
         this.member = member;

--- a/src/main/java/com/igocst/coco/dto/comment/CommentCreateRequestDto.java
+++ b/src/main/java/com/igocst/coco/dto/comment/CommentCreateRequestDto.java
@@ -1,15 +1,16 @@
 package com.igocst.coco.dto.comment;
 
-import com.igocst.coco.domain.Member;
-import com.igocst.coco.domain.Post;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentCreateRequestDto {
     private String content;
+    private LocalDateTime createDate = LocalDateTime.now();
 }

--- a/src/main/java/com/igocst/coco/dto/comment/CommentReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/comment/CommentReadResponseDto.java
@@ -2,6 +2,8 @@ package com.igocst.coco.dto.comment;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Setter
 @Getter
@@ -12,4 +14,5 @@ public class CommentReadResponseDto {
     //List가 아니라 String으로 해줘야함 왜냐하면, Comment entity에  getContent할 content가 String 타입이니까.
     private String nickname;
     private String status;
+    private LocalDateTime createDate;
 }

--- a/src/main/java/com/igocst/coco/service/CommentService.java
+++ b/src/main/java/com/igocst/coco/service/CommentService.java
@@ -38,6 +38,7 @@ public class CommentService {
         //Comment를 하나 만들고
         Comment comment = Comment.builder()
                 .content(commentCreateRequestDto.getContent())
+                .createDate(commentCreateRequestDto.getCreateDate())
                 .build();
         /*주인에게 연관관계 메소드를 통해 "이 댓글 내거야!" 하고 말해줌
         comment는 repo에서 꺼내온게 아니기 때문에 영속성이 없는상태
@@ -66,6 +67,7 @@ public class CommentService {
                     .comments(c.getContent())
                     .nickname(c.getMember().getNickname())
                     //c.getPost().getComments는 결국 댓글의 게시글을 불러와서 다시 그 댓글을 다 찍어준 것= 값이 두번씩 찍히는 에러
+                    .createDate(c.getCreateDate())
                     .status("댓글 불러오기 완료")
                     .build());
         }


### PR DESCRIPTION
** 기능 **
댓글 작성하면 다시 불러올 때 @닉네임 옆에 Time ago 생성
-  1분 미만은 `방금전` 으로 표시되고 그 이후엔 `~분/시간/일/년 전`...으로 표시됨

** 변경된 점**
서버 Comment.java에서 Timestamped 상속 받지 않고, Comment entity에서 createDate 필드를 만들어 사용함
- modifiedDate 필드 사라짐 추후 수정기능 구현시 다시 생성 가능!


