### PR TITLE
관리자 댓글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/igocst/coco/dto/comment/CommentReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/comment/CommentReadResponseDto.java
@@ -1,5 +1,6 @@
 package com.igocst.coco.dto.comment;
 
+import com.igocst.coco.domain.MemberRole;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -17,4 +18,6 @@ public class CommentReadResponseDto {
     private LocalDateTime createDate;
     // 댓글을 삭제 할 수 있는지 여부 체크
     private boolean enableDelete;
+    // 관리자 여부 체크
+    private MemberRole memberRole;
 }

--- a/src/main/java/com/igocst/coco/service/CommentService.java
+++ b/src/main/java/com/igocst/coco/service/CommentService.java
@@ -2,6 +2,7 @@ package com.igocst.coco.service;
 
 import com.igocst.coco.domain.Comment;
 import com.igocst.coco.domain.Member;
+import com.igocst.coco.domain.MemberRole;
 import com.igocst.coco.domain.Post;
 import com.igocst.coco.dto.comment.*;
 import com.igocst.coco.repository.CommentRepository;
@@ -59,10 +60,20 @@ public class CommentService {
         //List로 받고
         List<Comment> comments = commentRepository.findAllByPostId(post_id);
         List<CommentReadResponseDto> output = new ArrayList<>();
-        boolean enableDelete = false;
+        boolean enableDelete;
 
         for(Comment c : comments) {
+            enableDelete = false;
+
+            // 로그인한 회원은 본인이 작성한 댓글만 삭제할 수 있다.
             if (c.getMember().getId() == memberDetails.getMember().getId()) {
+                enableDelete = true;
+            }
+
+            // 현재 로그인한 회원이 관리자라면 모든 댓글을 삭제할 수 있다.
+            MemberRole memberRole = MemberRole.MEMBER;
+            if (memberDetails.getMember().getRole().equals(MemberRole.ADMIN)) {
+                memberRole = MemberRole.ADMIN;
                 enableDelete = true;
             }
 
@@ -74,6 +85,7 @@ public class CommentService {
                     .createDate(c.getCreateDate())
                     .status("댓글 불러오기 완료")
                     .enableDelete(enableDelete)
+                    .memberRole(memberRole)
                     .build());
         }
         return output;


### PR DESCRIPTION
#116 관리자는 모든 댓글을 삭제할 수 있도록 구현
추가로, 본인이 작성한 댓글이 아닌데도 댓글 '삭제'버튼이 발생하는 오류 해결