### PR TITLE
프로필 서비스 보완을 위한 멤버 코드 추가

### DIFF
--- a/src/main/java/com/igocst/coco/dto/member/RegisterRequestDto.java
+++ b/src/main/java/com/igocst/coco/dto/member/RegisterRequestDto.java
@@ -9,6 +9,7 @@ public class RegisterRequestDto {
     private String nickname;
     private String githubUrl;
     private String portfolioUrl;
+    private String introduction;
     // 관리자
     private boolean admin = false;
     private String adminToken = "";

--- a/src/main/java/com/igocst/coco/service/MemberService.java
+++ b/src/main/java/com/igocst/coco/service/MemberService.java
@@ -84,6 +84,7 @@ public class MemberService {
                 .nickname(requestDto.getNickname())
                 .githubUrl(requestDto.getGithubUrl())
                 .portfolioUrl(requestDto.getPortfolioUrl())
+                .introduction((requestDto.getIntroduction()))
                 .role(role) // 권한 추가 (ADMIN / MEMBER)
                 .build();
 
@@ -99,7 +100,7 @@ public class MemberService {
     public MemberReadResponseDto readMember(MemberDetails memberDetails) {
         Member member = memberRepository.findById(memberDetails.getMember().getId())
                 .orElseThrow(() -> new IllegalArgumentException("아이디가 존재하지 않습니다."));
-        
+
         return MemberReadResponseDto.builder()
                 .email(member.getEmail())
                 .nickname(member.getNickname())


### PR DESCRIPTION
#123 
- null 값으로 저장되던 부분을 '' 으로 저장되게 수정
- 회원가입시 자기소개를 적는 칸 없음
   - null값 저장을 피하기위해 RegisterRequestDto에서 자기소개를 받고, 프론트에서 처리