### PR TITLE
프로필 이미지 업로드 S3 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 # Gradle Caches
 **/.gradle/
 **/build/
+
+#applicaton.properties
+src/main/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/igocst/coco/controller/MemberController.java
+++ b/src/main/java/com/igocst/coco/controller/MemberController.java
@@ -4,15 +4,12 @@ import com.igocst.coco.domain.MemberRole;
 import com.igocst.coco.dto.member.*;
 import com.igocst.coco.s3.S3Service;
 import com.igocst.coco.security.MemberDetails;
-import com.igocst.coco.security.jwt.JwtTokenProvider;
 import com.igocst.coco.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
+
 import java.io.IOException;
 
 
@@ -51,13 +48,8 @@ public class MemberController {
     public MemberReadResponseDto readMember(@AuthenticationPrincipal MemberDetails memberDetails) {
         return memberService.readMember(memberDetails);
     }
-    //회원 정보 수정
-//    @PutMapping("/user")
-//    public MemberUpdateResponseDto updateMember(@RequestBody MemberUpdateRequestDto memberUpdateRequestDto,
-//                                                                @AuthenticationPrincipal MemberDetails memberDetails) {
-//        return memberService.updateMember(memberUpdateRequestDto, memberDetails);
-//    }
 
+    //회원 정보 수정
     @PutMapping("/user")
     public MemberUpdateResponseDto updateMember(@ModelAttribute MemberUpdateRequestDto memberUpdateRequestDto,
                                                 @AuthenticationPrincipal MemberDetails memberDetails)
@@ -103,9 +95,9 @@ public class MemberController {
         return memberService.checkNicknameDup(checkNicknameDupRequestDto);
     }
 
-//    @PostMapping("/user/profile")
-//    public String upload(@RequestParam("profileImageUrl") MultipartFile multipartFile) throws IOException {
-//        s3Service.upload(multipartFile, "profileImage");
-//        return "test";
-//    }
+    // 프로필 모달 닉네임 중복 체크
+    @PutMapping("/user/check-nickname")
+    public CheckDupResponseDto checkNicknameDupProfile(@RequestBody CheckNicknameDupRequestDto checkNicknameDupRequestDto) {
+        return memberService.checkNicknameDup(checkNicknameDupRequestDto);
+    }
 }

--- a/src/main/java/com/igocst/coco/controller/MemberController.java
+++ b/src/main/java/com/igocst/coco/controller/MemberController.java
@@ -2,13 +2,18 @@ package com.igocst.coco.controller;
 
 import com.igocst.coco.domain.MemberRole;
 import com.igocst.coco.dto.member.*;
+import com.igocst.coco.s3.S3Service;
 import com.igocst.coco.security.MemberDetails;
 import com.igocst.coco.security.jwt.JwtTokenProvider;
 import com.igocst.coco.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
 
 @RestController
@@ -16,7 +21,8 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
-    private final JwtTokenProvider jwtTokenProvider;
+//    private final JwtTokenProvider jwtTokenProvider;
+    private final S3Service s3Service;
 
     // 로그인
     @PostMapping("/login")
@@ -46,11 +52,21 @@ public class MemberController {
         return memberService.readMember(memberDetails);
     }
     //회원 정보 수정
+//    @PutMapping("/user")
+//    public MemberUpdateResponseDto updateMember(@RequestBody MemberUpdateRequestDto memberUpdateRequestDto,
+//                                                                @AuthenticationPrincipal MemberDetails memberDetails) {
+//        return memberService.updateMember(memberUpdateRequestDto, memberDetails);
+//    }
+
     @PutMapping("/user")
-    public MemberUpdateResponseDto updateMember(@RequestBody MemberUpdateRequestDto memberUpdateRequestDto,
-                                                @AuthenticationPrincipal MemberDetails memberDetails) {
-        return memberService.updateMember(memberUpdateRequestDto, memberDetails);
+    public MemberUpdateResponseDto updateMember(@ModelAttribute MemberUpdateRequestDto memberUpdateRequestDto,
+                                                @AuthenticationPrincipal MemberDetails memberDetails)
+            throws IOException {
+//                s3Service.upload(memberUpdateRequestDto.getFile(), "test.png");
+                // TODO: S3에서 받은 이미지 url을 받아서 넣어줘야함. 리턴값이 url로 반환됨
+            return memberService.updateMember(memberUpdateRequestDto, memberDetails);
     }
+
 
     // 회원 탈퇴
     @DeleteMapping("/user")
@@ -86,4 +102,10 @@ public class MemberController {
     public CheckDupResponseDto checkNicknameDup(@RequestBody CheckNicknameDupRequestDto checkNicknameDupRequestDto) {
         return memberService.checkNicknameDup(checkNicknameDupRequestDto);
     }
+
+//    @PostMapping("/user/profile")
+//    public String upload(@RequestParam("profileImageUrl") MultipartFile multipartFile) throws IOException {
+//        s3Service.upload(multipartFile, "profileImage");
+//        return "test";
+//    }
 }

--- a/src/main/java/com/igocst/coco/domain/Member.java
+++ b/src/main/java/com/igocst/coco/domain/Member.java
@@ -197,4 +197,8 @@ public class Member extends Timestamped {
     public void updateIntroduction(String introduction){
         this.introduction = introduction;
     }
+
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/com/igocst/coco/dto/member/MemberReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/member/MemberReadResponseDto.java
@@ -14,4 +14,6 @@ public class MemberReadResponseDto {
     private String portfolioUrl;
     private String introduction;
     private String status;
+    // 프로필 페이지 이미지
+    private String profileImageUrl;
 }

--- a/src/main/java/com/igocst/coco/dto/member/MemberUpdateRequestDto.java
+++ b/src/main/java/com/igocst/coco/dto/member/MemberUpdateRequestDto.java
@@ -3,6 +3,9 @@ package com.igocst.coco.dto.member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Setter
 @Getter
@@ -10,9 +13,11 @@ import lombok.Setter;
 public class MemberUpdateRequestDto {
     // TODO: password 검사하고 수정 가능하도록, imageUrl도 넣어줘야함.
     //private String password;
-    //private String imageUrl
     private String nickname;
     private String githubUrl;
     private String portfolioUrl;
     private String introduction;
+    //프로필 페이지 이미지
+    private MultipartFile file;
+//    private String profileImageUrl;
 }

--- a/src/main/java/com/igocst/coco/dto/member/RegisterRequestDto.java
+++ b/src/main/java/com/igocst/coco/dto/member/RegisterRequestDto.java
@@ -10,6 +10,7 @@ public class RegisterRequestDto {
     private String githubUrl;
     private String portfolioUrl;
     private String introduction;
+    private String profileImageUrl;
     // 관리자
     private boolean admin = false;
     private String adminToken = "";

--- a/src/main/java/com/igocst/coco/repository/MemberRepository.java
+++ b/src/main/java/com/igocst/coco/repository/MemberRepository.java
@@ -4,6 +4,7 @@ import com.igocst.coco.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
+import java.io.File;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {

--- a/src/main/java/com/igocst/coco/s3/AmazonS3Config.java
+++ b/src/main/java/com/igocst/coco/s3/AmazonS3Config.java
@@ -1,0 +1,31 @@
+package com.igocst.coco.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmazonS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/com/igocst/coco/s3/AmazonS3Config.java
+++ b/src/main/java/com/igocst/coco/s3/AmazonS3Config.java
@@ -10,12 +10,15 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class AmazonS3Config {
-
+    //AmazonS3Client를 Build 해주는 cofig 생성
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
 
     @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
+
+//    @Value("${cloud.aws.s3.bucket}")
+//    private String bucket;
 
     @Value("${cloud.aws.region.static}")
     private String region;

--- a/src/main/java/com/igocst/coco/s3/S3Service.java
+++ b/src/main/java/com/igocst/coco/s3/S3Service.java
@@ -1,0 +1,119 @@
+package com.igocst.coco.s3;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Service {
+    static { System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true"); }
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    public String bucket;
+
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile)
+                // 파일 변환할 수 없으면 에러
+                .orElseThrow(() -> new IllegalArgumentException("error: MultipartFile -> File convert fail"));
+
+        return upload(uploadFile, dirName);
+
+    }
+
+    // S3로 파일 업로드하기
+    private String upload(File uploadFile, String dirName) {
+        //filename을 받고 -> uploadImageUrl을 반환 받음(39번쨰줄)
+        String fileName = dirName + "/" + UUID.randomUUID() + uploadFile.getName();   // S3에 저장된 파일 이름
+        String uploadImageUrl = putS3(uploadFile, fileName); // s3로 업로드
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    // S3로 업로드
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    // 로컬에 저장된 이미지 지우기
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("File delete success");
+            return;
+        }
+        log.info("File delete fail");
+    }
+
+    // 로컬에 파일 업로드 하기
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(System.getProperty("user.dir") + "/" + file.getOriginalFilename());
+        if (convertFile.createNewFile()) { // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) { // FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+
+        return Optional.empty();
+    }
+    // 다른버전으로 시도
+//public String upload(MultipartFile file, String profileImage) {
+//    String key = UUID.randomUUID() + "_" + file.getOriginalFilename();
+//    try {
+//
+//        ObjectMetadata metadata = new ObjectMetadata();
+//        metadata.setContentType(file.getContentType());
+//        PutObjectRequest request = new PutObjectRequest(bucket, key, file.getInputStream(), metadata);
+//        request.withCannedAcl(CannedAccessControlList.PublicRead); // 접근권한 체크
+//        PutObjectResult result = amazonS3Client.putObject(request);
+//        return key;
+//    } catch (AmazonServiceException e) {
+//        // The call was transmitted successfully, but Amazon S3 couldn't process
+//        // it, so it returned an error response.
+//        log.error("upload AmazonServiceException filePath={}, yyyymm={}, error={}", e.getMessage());
+//    } catch (SdkClientException e) {
+//        // Amazon S3 couldn't be contacted for a response, or the client
+//        // couldn't parse the response from Amazon S3.
+//        log.error("upload SdkClientException filePath={}, error={}", e.getMessage());
+//    } catch (Exception e) {
+//        // Amazon S3 couldn't be contacted for a response, or the client
+//        // couldn't parse the response from Amazon S3.
+//        log.error("upload SdkClientException filePath={}, error={}", e.getMessage());
+//    }
+//
+//    return key;
+//}
+//
+//    public void delete(String fileKey) {
+//        amazonS3Client.deleteObject(bucket, fileKey);
+//    }
+//
+//    public void rename(String sourceKey, String destinationKey){
+//        amazonS3Client.copyObject(
+//                bucket,
+//                sourceKey,
+//                bucket,
+//                destinationKey
+//        );
+//        amazonS3Client.deleteObject(bucket, sourceKey);
+//    }
+}

--- a/src/main/java/com/igocst/coco/s3/S3Service.java
+++ b/src/main/java/com/igocst/coco/s3/S3Service.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -74,9 +75,9 @@ public class S3Service {
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
-    private void delete(String fileKey) {
-        amazonS3Client.deleteObject(bucket, fileKey);
-    }
+//    private void delete(String fileKey) {
+//        amazonS3Client.deleteObject(bucket, fileKey);
+//    }
 //   public String reupload(MultipartFile file, String currentFilePath, String imageKey) {
 //        String fileName =
 //    }

--- a/src/main/java/com/igocst/coco/security/MemberDetails.java
+++ b/src/main/java/com/igocst/coco/security/MemberDetails.java
@@ -8,7 +8,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 
 public class MemberDetails implements UserDetails {
 

--- a/src/main/java/com/igocst/coco/security/SecurityConfiguration.java
+++ b/src/main/java/com/igocst/coco/security/SecurityConfiguration.java
@@ -47,6 +47,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // cors 때문에 추가
                 .antMatchers("/h2-console/**").permitAll()
                 .antMatchers("/register/**").permitAll()
+                .antMatchers("/user/**").permitAll()
                 .antMatchers("/login").permitAll()
                 .antMatchers("/post/list").permitAll()
                 .antMatchers("/post/recruit/list").permitAll()

--- a/src/main/java/com/igocst/coco/service/MemberService.java
+++ b/src/main/java/com/igocst/coco/service/MemberService.java
@@ -1,15 +1,9 @@
 package com.igocst.coco.service;
 
 
-import com.igocst.coco.domain.Comment;
 import com.igocst.coco.domain.Member;
 import com.igocst.coco.domain.MemberRole;
-import com.igocst.coco.dto.comment.CommentReadResponseDto;
-import com.igocst.coco.dto.comment.CommentUpdateRequestDto;
-import com.igocst.coco.dto.comment.CommentUpdateResponseDto;
 import com.igocst.coco.dto.member.*;
-import com.igocst.coco.dto.message.MessageDeleteResponseDto;
-import com.igocst.coco.dto.message.MessageReadResponseDto;
 import com.igocst.coco.repository.MemberRepository;
 import com.igocst.coco.s3.S3Service;
 import com.igocst.coco.security.MemberDetails;
@@ -22,8 +16,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -127,11 +119,12 @@ public class MemberService {
         if (member == null) {
             throw new RuntimeException("프로필 수정 권한이 없습니다.");
         }
+
         //파일을 getfile로 해서 받음
         MultipartFile file = memberUpdateRequestDto.getFile();
         // 분기 처리
         if (file != null) {
-            String fileUrl = s3Service.upload(file, "profileImage");
+            String fileUrl = s3Service.upload(file, "profileImage", memberDetails);
             member.updateProfileImage(fileUrl);
         }
 
@@ -213,4 +206,18 @@ public class MemberService {
                 .isDup(isDup)
                 .build();
     }
+
+    //프로필 모달에서 닉네임 중복체크
+//    public CheckDupResponseDto checkNicknameDupProfile(CheckNicknameDupRequestDto checkNicknameDupRequestDto) {
+//
+//        //닉네임이 기존 닉네임과 같지 않을 때 동작
+//        String nickname = checkNicknameDupRequestDto.getNickname();
+//        if (nickname != checkNicknameDupRequestDto.getNickname()) {
+//            boolean isDup = memberRepository.findByNickname(nickname).isPresent();
+//        }
+//
+//        return CheckDupResponseDto.builder()
+//                .isDup(isDup)
+//                .build();
+//    }
 }

--- a/src/main/java/com/igocst/coco/service/MemberService.java
+++ b/src/main/java/com/igocst/coco/service/MemberService.java
@@ -11,14 +11,17 @@ import com.igocst.coco.dto.member.*;
 import com.igocst.coco.dto.message.MessageDeleteResponseDto;
 import com.igocst.coco.dto.message.MessageReadResponseDto;
 import com.igocst.coco.repository.MemberRepository;
+import com.igocst.coco.s3.S3Service;
 import com.igocst.coco.security.MemberDetails;
 import com.igocst.coco.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +30,7 @@ import java.util.List;
 @Slf4j
 public class MemberService {
 
-
+    private final S3Service s3Service;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private static final String ADMIN_TOKEN = "sflIQ7FG381ei013i/SDGLYFuFua";   // 임시 관리자 토큰
@@ -82,6 +85,7 @@ public class MemberService {
                 .email(requestDto.getEmail())
                 .password(passwordEncoder.encode(requestDto.getPassword()))
                 .nickname(requestDto.getNickname())
+                .profileImageUrl(requestDto.getProfileImageUrl())
                 .githubUrl(requestDto.getGithubUrl())
                 .portfolioUrl(requestDto.getPortfolioUrl())
                 .introduction((requestDto.getIntroduction()))
@@ -107,6 +111,7 @@ public class MemberService {
                 .githubUrl(member.getGithubUrl())
                 .portfolioUrl(member.getPortfolioUrl())
                 .introduction(member.getIntroduction())
+                .profileImageUrl(member.getProfileImageUrl())
                 .status("회원 정보 불러오기 완료")
                 .build();
     }
@@ -114,7 +119,7 @@ public class MemberService {
     // 회원 정보 수정
     @Transactional
     public MemberUpdateResponseDto updateMember(MemberUpdateRequestDto memberUpdateRequestDto,
-                                                MemberDetails memberDetails) {
+                                                MemberDetails memberDetails) throws IOException {
         //멤버를 찾고
         Member member = memberRepository.findById(memberDetails.getMember().getId())
                 .orElseThrow(() -> new IllegalArgumentException("아이디가 존재하지 않습니다."));
@@ -122,13 +127,28 @@ public class MemberService {
         if (member == null) {
             throw new RuntimeException("프로필 수정 권한이 없습니다.");
         }
-        
+        //파일을 getfile로 해서 받음
+        MultipartFile file = memberUpdateRequestDto.getFile();
+        String fileUrl = s3Service.upload(file, "profileImage");
+        // TODO: Step 1. 똑같은 정보를 준건지, 하나라도 수정이 된건지 체크! -> 조건문으로 분기처리를해서 돌아가는지 테스트해봐야할듯.(DB에 최소한으로 다녀오기!)
+        // TODO: Step 2. S3에 저장하기(S3에 저장해야 해당 파일에 대한 url에 반환되기 때문에!)
+        // TODO: Step 3. DB에 저장하기(반환된 S3에 저장되어있는 url을 DB에 저장)
+        // TODO: Step 4. 왜 IOException 같은 예외처리를 해줘야했는지 설명할 수 있을 정도로 파악해보기.
+
+        // 이전과 달라진 내용만 DB애 upload될 수 있도록 / client단에서 체크를해도됨
+        //  but + 백엔드에서만 체크를하면 더 좋을듯...
+
         // TODO: password 수정하려면 기존 비번 확인하는거 필요, imageUrl도 추가해야함.
         //그 멤버의 정보를 바꾼다.
         member.updateNickname(memberUpdateRequestDto.getNickname());
         member.updateGithubUrl(memberUpdateRequestDto.getGithubUrl());
         member.updatePortfolioUrl(memberUpdateRequestDto.getPortfolioUrl());
         member.updateIntroduction(memberUpdateRequestDto.getIntroduction());
+        //updateRequestDto단에서 ProfileImageUrl 받을 이유가 없응ㅁ.
+//        member.updateProfileImage(memberUpdateRequestDto.getProfileImageUrl());
+        member.updateProfileImage(fileUrl);
+
+        memberRepository.save(member);
 
         return MemberUpdateResponseDto.builder()
                 .status("회원 정보가 수정되었습니다")

--- a/src/main/java/com/igocst/coco/service/MemberService.java
+++ b/src/main/java/com/igocst/coco/service/MemberService.java
@@ -10,6 +10,7 @@ import com.igocst.coco.security.MemberDetails;
 import com.igocst.coco.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.MultipartStream;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -118,6 +119,10 @@ public class MemberService {
 
         if (member == null) {
             throw new RuntimeException("프로필 수정 권한이 없습니다.");
+        }
+
+        if(memberRepository.findByNickname(memberUpdateRequestDto.getNickname()).isPresent()) {
+            throw new IllegalArgumentException("중복된 닉네임을 가진 회원이 존재합니다.");
         }
 
         //파일을 getfile로 해서 받음

--- a/src/main/java/com/igocst/coco/service/MemberService.java
+++ b/src/main/java/com/igocst/coco/service/MemberService.java
@@ -129,7 +129,12 @@ public class MemberService {
         }
         //파일을 getfile로 해서 받음
         MultipartFile file = memberUpdateRequestDto.getFile();
-        String fileUrl = s3Service.upload(file, "profileImage");
+        // 분기 처리
+        if (file != null) {
+            String fileUrl = s3Service.upload(file, "profileImage");
+            member.updateProfileImage(fileUrl);
+        }
+
         // TODO: Step 1. 똑같은 정보를 준건지, 하나라도 수정이 된건지 체크! -> 조건문으로 분기처리를해서 돌아가는지 테스트해봐야할듯.(DB에 최소한으로 다녀오기!)
         // TODO: Step 2. S3에 저장하기(S3에 저장해야 해당 파일에 대한 url에 반환되기 때문에!)
         // TODO: Step 3. DB에 저장하기(반환된 S3에 저장되어있는 url을 DB에 저장)
@@ -146,7 +151,6 @@ public class MemberService {
         member.updateIntroduction(memberUpdateRequestDto.getIntroduction());
         //updateRequestDto단에서 ProfileImageUrl 받을 이유가 없응ㅁ.
 //        member.updateProfileImage(memberUpdateRequestDto.getProfileImageUrl());
-        member.updateProfileImage(fileUrl);
 
         memberRepository.save(member);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=none
 
 spring.h2.console.enabled=true
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,4 @@ spring.jpa.hibernate.ddl-auto=none
 
 spring.h2.console.enabled=true
 
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,5 +9,3 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=none
 
 spring.h2.console.enabled=true
-
-


### PR DESCRIPTION
#126 S3, image 연동 
- 프로필 이미지 업로드시 S3 버킷에 자동 업로드
   - 이미지 파일 이름: user의 고유값 이용해서 난수화
   - 프로필 재수정시 원래있던 이미지 파일 위로 덮어쓰기 됨
   (굳이 기존파일 지우고 현재 파일로 대체되는 로직이 아님! -> 굿)

- 프로필 수정시 닉네임 중복확인
   - 중복확인 실패
