### PR TITLE
쪽지 상세 읽기 & 쪽지 답장보내기 구현

### DIFF
--- a/src/main/java/com/igocst/coco/domain/Member.java
+++ b/src/main/java/com/igocst/coco/domain/Member.java
@@ -141,6 +141,11 @@ public class Member extends Timestamped {
                 return Optional.ofNullable(message);
             }
         }
+        for (Message message : sendMessage) {
+            if (message.getId() == messageId) {
+                return Optional.ofNullable(message);
+            }
+        }
         return Optional.empty();
     }
 

--- a/src/main/java/com/igocst/coco/domain/Member.java
+++ b/src/main/java/com/igocst/coco/domain/Member.java
@@ -162,6 +162,13 @@ public class Member extends Timestamped {
                 return true;
             }
         }
+        Iterator<Message> sendIterator = sendMessage.iterator();
+        while (sendIterator.hasNext()) {
+            if (sendIterator.next().getId().equals(messageId)) {
+                sendIterator.remove();
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/main/java/com/igocst/coco/dto/message/MessageReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/message/MessageReadResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Builder
 @Getter
 public class MessageReadResponseDto {
+    private String receiver;
     private String sender;
     private String title;
     private String content;

--- a/src/main/java/com/igocst/coco/dto/message/MessageReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/message/MessageReadResponseDto.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Builder
 @Getter
 public class MessageReadResponseDto {
-    private String receiver;
+    private Long id;
+    private String member;
     private String sender;
     private String title;
     private String content;

--- a/src/main/java/com/igocst/coco/service/MessageService.java
+++ b/src/main/java/com/igocst/coco/service/MessageService.java
@@ -92,8 +92,9 @@ public class MessageService {
 
         return new ResponseEntity<>(
                 MessageReadResponseDto.builder()
-                        .receiver(message.getSender().getEmail())
-                        .sender(message.getSender().getEmail())
+                        .id(message.getId())
+                        .member(member.getNickname())
+                        .sender(message.getSender().getNickname())
                         .title(message.getTitle())
                         .content(message.getContent())
                         .readState(message.isReadState())

--- a/src/main/java/com/igocst/coco/service/MessageService.java
+++ b/src/main/java/com/igocst/coco/service/MessageService.java
@@ -92,6 +92,7 @@ public class MessageService {
 
         return new ResponseEntity<>(
                 MessageReadResponseDto.builder()
+                        .receiver(message.getSender().getEmail())
                         .sender(message.getSender().getEmail())
                         .title(message.getTitle())
                         .content(message.getContent())


### PR DESCRIPTION
#171 #172 #173 
- 쪽지 상세읽기 구현
   - Member 엔티티에서 기존에 쪽지 상세읽기를 위해 정의해놓은 메소드인 findMessage는
   받은 쪽지(readMessage)만을 찾았는데, 보낸쪽지(sendMessage)도 한번에 찾을 수 있도록 코드 작성
- 받은 쪽지에서 답장보내기 버튼을 통해 바로 답장을 보낼 수 있도록 연결
   - 로그인한 사용자(member)의 닉네임이 sender의 닉네임과 같다면,
   쪽지 상세 모달에서 답장보내기 버튼이 보이지 않게 하기 위해서 Dto로 정보를 보내줌.
   ↳ 보낸 쪽지함에서 쪽지를 볼 때도 동일
- 보낸 쪽지 삭제하기
   - Member 엔티티에서 deleteMessage 메소드에 본인이 작성한 메시지도 지울 수 있도록 Iterator 추가