### PR TITLE
비교 연산자 수정

### DIFF
--- a/src/main/java/com/igocst/coco/domain/Member.java
+++ b/src/main/java/com/igocst/coco/domain/Member.java
@@ -117,7 +117,8 @@ public class Member extends Timestamped {
             return Optional.empty();
         }
         for (Comment comment : comments) {
-            if (comment.getId() == commentId) {
+            Long com = comment.getId();
+            if (com.equals(commentId)) {
                 return Optional.ofNullable(comment);
             }
         }


### PR DESCRIPTION
#185 댓글 수정완료 버튼 누를 때 400 에러
- 댓글 수정시 400 error 뜸
   - commentId는 Long 타입인데, Long 타입은 끝에 L이 붙으므로
   비교연산자 ==가 아니라 .equals( )를 사용해 줘야한다. 