### PR TITLE
게시글을 북마크에 저장하면 State를  TRUE로 저장하도록 구현

### DIFF
--- a/src/main/java/com/igocst/coco/domain/Bookmark.java
+++ b/src/main/java/com/igocst/coco/domain/Bookmark.java
@@ -28,10 +28,13 @@ public class Bookmark {
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
+    @Column(nullable = false)
+    private boolean bookmarkState;
     public void registerMember(Member member) {
         this.member = member;
     }
     public void registerPost(Post post) {
         this.post = post;
     }
+    public void changeBookmarkState() { this.bookmarkState = true; }
 }

--- a/src/main/java/com/igocst/coco/dto/bookmark/BookmarkListReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/bookmark/BookmarkListReadResponseDto.java
@@ -17,4 +17,5 @@ public class BookmarkListReadResponseDto {
     private String period;
     private boolean recruitmentState;
     private int hits;
+    private boolean bookmarkState;
 }

--- a/src/main/java/com/igocst/coco/dto/message/MessageListReadResponseDto.java
+++ b/src/main/java/com/igocst/coco/dto/message/MessageListReadResponseDto.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 public class MessageListReadResponseDto {
     private Long id;
     private String title;
+    private String content;
     private String receiver;
     private String sender;
     private Boolean readState;

--- a/src/main/java/com/igocst/coco/service/BookmarkService.java
+++ b/src/main/java/com/igocst/coco/service/BookmarkService.java
@@ -32,7 +32,6 @@ public class BookmarkService {
     // 북마크에 저장하기
     @Transactional
     public ResponseEntity<BookmarkSaveResponseDto> saveBookmark(Long postId, MemberDetails memberDetails) {
-        // 영속성이 없는상태
         Optional<Member> memberOptional = memberRepository.findById(memberDetails.getMember().getId());
         Member member = memberOptional.get();
 
@@ -61,6 +60,7 @@ public class BookmarkService {
         Bookmark bookmark = new Bookmark();
         member.addBookmark(bookmark);
         post.addBookmark(bookmark);
+        bookmark.changeBookmarkState();
         bookmarkRepository.save(bookmark);
 
         return new ResponseEntity<>(
@@ -87,6 +87,7 @@ public class BookmarkService {
                     .period(b.getPost().getPeriod())
                     .recruitmentState(b.getPost().isRecruitmentState())
                     .hits(b.getPost().getHits())
+                    .bookmarkState(b.isBookmarkState())
                     .status(StatusMessage.SUCCESS)
                     .build());
         }

--- a/src/main/java/com/igocst/coco/service/MessageService.java
+++ b/src/main/java/com/igocst/coco/service/MessageService.java
@@ -70,7 +70,7 @@ public class MessageService {
         );
     }
 
-    // 쪽지 상세 읽기
+    // 받은 쪽지 상세 읽기
     @Transactional
     public ResponseEntity<MessageReadResponseDto> getMessage(Long messageId, MemberDetails memberDetails) {
 
@@ -139,6 +139,7 @@ public class MessageService {
             sendMessageList.add(MessageListReadResponseDto.builder()
                 .id(m.getId())
                 .title(m.getTitle())
+                .content(m.getContent())
                 .receiver(m.getReceiver().getNickname())
                 .readState(m.isReadState())
                 .createDate(m.getCreateDate())


### PR DESCRIPTION
#188 
- 홈 화면 게시글 리스트에서
북마크로 저장한 게시글은 state를 TRUE로 저장하도록해서,
 프론트에서 북마크 아이콘이 state가  TRUE면 색칠되도록 구현
- 보낸 사람이 쪽지를 확인할 경우, 받은 사람 쪽지도 읽음으로 변경되는 오류 수정