### PR TITLE
북마크 StatusMessage 수정

### DIFF
--- a/src/main/java/com/igocst/coco/common/status/StatusMessage.java
+++ b/src/main/java/com/igocst/coco/common/status/StatusMessage.java
@@ -9,4 +9,5 @@ public class StatusMessage {
     public static final String UNAUTHORIZED_USER = "Unauthorized user";
     public static final String FORBIDDEN_USER = "Forbidden user";
     public static final String DUPLICATED_USER = "Duplicated user";
+    public static final String DUPLICATED_BOOKMARK = "Duplicated bookmark";
 }

--- a/src/main/java/com/igocst/coco/service/BookmarkService.java
+++ b/src/main/java/com/igocst/coco/service/BookmarkService.java
@@ -37,7 +37,7 @@ public class BookmarkService {
 
         Optional<Post> postOptional  = postRepository.findById(postId);
         if(postOptional.isEmpty()) {
-            log.error("nickname={}, messageId={}, error={}", member.getNickname(), postId, "해당 게시글을 찾을 수 없음");
+            log.error("nickname={}, postId={}, error={}", member.getNickname(), postId, "해당 게시글을 찾을 수 없음");
             return new ResponseEntity<>(
                     BookmarkSaveResponseDto.builder().status(StatusMessage.BAD_REQUEST).build(),
                     HttpStatus.valueOf(StatusCode.BAD_REQUEST));
@@ -49,9 +49,9 @@ public class BookmarkService {
 
             // 이미 본인이 저장한 북마크는 또 저장할 수 없음
             if (b.getMember().getId() == memberDetails.getMember().getId()) {
-                log.error("nickname={}, messageId={}, error={}", member.getNickname(), postId, "이미 북마크에 저장한 게시글");
+                log.error("nickname={}, postId={}, error={}", member.getNickname(), postId, "이미 북마크에 저장한 게시글");
                 return new ResponseEntity<>(
-                        BookmarkSaveResponseDto.builder().status(StatusMessage.BAD_REQUEST).build(),
+                        BookmarkSaveResponseDto.builder().status(StatusMessage.DUPLICATED_BOOKMARK).build(),
                         HttpStatus.valueOf(StatusCode.BAD_REQUEST)
                 );
             }


### PR DESCRIPTION
#189 
- postId가 DB에 없을 때와 이미 북마크에 저장된 게시글을 저장할 때에 
같은 에러메시지가 나갔던 것을 StatusMessage를 따로 구별하도록 수정 